### PR TITLE
Fixed Issue #7 and fixed grammar

### DIFF
--- a/test_triegex.py
+++ b/test_triegex.py
@@ -28,7 +28,7 @@ class TriegexTest(TestCase):
 
     def test_optimized(self):
         t = triegex.Triegex('Jon', 'Jorah')
-        self.assertEqual(r'(?:Jo(?:n\b|rah\b)|~^(?#match nothing))', t.to_regex())
+        self.assertEqual(r'(?:~^(?#match nothing)|Jo(?:n\b|rah\b))', t.to_regex())
 
 
 class TriegexMutableSetInterfaceTest(TestCase):

--- a/test_triegex.py
+++ b/test_triegex.py
@@ -28,7 +28,7 @@ class TriegexTest(TestCase):
 
     def test_optimized(self):
         t = triegex.Triegex('Jon', 'Jorah')
-        self.assertEqual(r'(?:~^(?#match nothing)|Jo(?:n\b|rah\b))', t.to_regex())
+        self.assertEqual(r'(?:Jo(?:n\b|rah\b)|~^(?#match nothing))', t.to_regex())
 
 
 class TriegexMutableSetInterfaceTest(TestCase):

--- a/triegex/__init__.py
+++ b/triegex/__init__.py
@@ -14,33 +14,33 @@ WORD_BOUNDARY = r'\b'
 
 class TriegexNode:
 
-    def __init__(self, char: str, end: bool, *childrens):
+    def __init__(self, char: str, end: bool, *children):
         self.char = char if char is not None else ''
         self.end = end
-        self.childrens = {children.char: children for children in childrens}
+        self.children = {child.char: child for child in children}
 
     def __iter__(self):
-        return iter(sorted(self.childrens.values(), key=lambda x: x.char))
+        return iter(sorted(self.children.values(), key=lambda x: x.char))
 
     def __len__(self):
-        return len(self.childrens)
+        return len(self.children)
 
     def __repr__(self):
         return "<TriegexNode: '{0.char}' end={0.end}>".format(self)
 
     def __contains__(self, key):
-        return key in self.childrens
+        return key in self.children
 
     def __getitem__(self, key):
-        return self.childrens[key]
+        return self.children[key]
 
     def __delitem__(self, key):
-        del self.childrens[key]
+        del self.children[key]
 
     def to_regex(self):
         '''
         RECURSIVE IMPLEMENTATION FOR REFERENCE
-        suffixes = [v.to_regex() for k, v in self.childrens.items()]
+        suffixes = [v.to_regex() for k, v in self.children.items()]
         if self.end:
             suffixes += [WORD_BOUNDARY]
         
@@ -60,9 +60,9 @@ class TriegexNode:
         i = 0
         j = 1
         while i < len(stack):
-            stack.extend(stack[i].childrens.values())
+            stack.extend(stack[i].children.values())
             lookup.append(j)
-            j += len(stack[i].childrens)
+            j += len(stack[i].children)
             i += 1
         
         i = len(stack)
@@ -73,7 +73,7 @@ class TriegexNode:
             i -= 1
             node = stack[i]
             # Get regexes of child nodes and make a root regex
-            suffixes = [sub_regexes[child] for child in range(lookup[i], lookup[i] + len(node.childrens))]
+            suffixes = [sub_regexes[child] for child in range(lookup[i], lookup[i] + len(node.children))]
             if node.end:
                 # if the node is an ending node we add a \b character
                 suffixes += [WORD_BOUNDARY]
@@ -102,13 +102,13 @@ class Triegex(collections.MutableSet):
     def add(self, word: str):
         current = self._root
         for letter in word[:-1]:
-            current = current.childrens.setdefault(letter,
+            current = current.children.setdefault(letter,
                                                    TriegexNode(letter, False))
         # this will ensure that we correctly match the word boundary
-        if word[-1] in current.childrens:
-            current.childrens[word[-1]].end = True
+        if word[-1] in current.children:
+            current.children[word[-1]].end = True
         else:
-            current.childrens[word[-1]] = TriegexNode(word[-1], True)
+            current.children[word[-1]] = TriegexNode(word[-1], True)
 
     def to_regex(self):
         r"""
@@ -127,15 +127,15 @@ class Triegex(collections.MutableSet):
         while stack:
             yield current
             current = stack.pop()
-            stack.extend(current.childrens.values())
+            stack.extend(current.children.values())
 
     def __iter__(self):
         paths = {self._root.char: []}
         for node in self._traverse():
-            for children in node:
-                paths[children.char] = [node.char] + paths[node.char]
-                if children.end:
-                    char = children.char
+            for child in node:
+                paths[child.char] = [node.char] + paths[node.char]
+                if child.end:
+                    char = child.char
                     yield ''.join(reversed([char] + paths[char]))
 
     def __len__(self):

--- a/triegex/__init__.py
+++ b/triegex/__init__.py
@@ -40,7 +40,7 @@ class TriegexNode:
     def to_regex(self):
         '''
         RECURSIVE IMPLEMENTATION FOR REFERENCE
-        suffixes = [v.to_regex() for k, v in self.children.items()]
+        suffixes = reversed([v.to_regex() for k, v in self.children.items()])
         if self.end:
             suffixes += [WORD_BOUNDARY]
         
@@ -73,7 +73,8 @@ class TriegexNode:
             i -= 1
             node = stack[i]
             # Get regexes of child nodes and make a root regex
-            suffixes = [sub_regexes[child] for child in range(lookup[i], lookup[i] + len(node.children))]
+            # Iterate backwards because otherwise alphabetical ordering is incorrect
+            suffixes = [sub_regexes[lookup[i] + len(node.children) - 1 - child] for child in range(0, len(node.children))]
             if node.end:
                 # if the node is an ending node we add a \b character
                 suffixes += [WORD_BOUNDARY]

--- a/triegex/__init__.py
+++ b/triegex/__init__.py
@@ -77,6 +77,9 @@ class TriegexNode:
             if node.end:
                 # if the node is an ending node we add a \b character
                 suffixes += [WORD_BOUNDARY]
+            # If we arrive at the root node we have to add the NOTHING expression
+            if i == 0:
+                suffixes += [NOTHING]
             if len(suffixes) > 1:
                 sub_regexes[i] = node.char + GROUP.format(OR.join(suffixes))
             elif len(suffixes) == 1:
@@ -93,8 +96,7 @@ class Triegex(collections.MutableSet):
         Trigex constructor.
         """
 
-        # make sure we match nothing when no words are added
-        self._root = TriegexNode(None, False, TriegexNode(NOTHING, False))
+        self._root = TriegexNode(None, False)
 
         for word in words:
             self.add(word)
@@ -102,8 +104,11 @@ class Triegex(collections.MutableSet):
     def add(self, word: str):
         current = self._root
         for letter in word[:-1]:
-            current = current.children.setdefault(letter,
-                                                   TriegexNode(letter, False))
+            if letter in current.children:
+                current = current.children[letter]
+            else:
+                current = current.children.setdefault(letter,
+                                                      TriegexNode(letter, False))
         # this will ensure that we correctly match the word boundary
         if word[-1] in current.children:
             current.children[word[-1]].end = True

--- a/triegex/__init__.py
+++ b/triegex/__init__.py
@@ -60,7 +60,7 @@ class TriegexNode:
         i = 0
         j = 1
         while i < len(stack):
-            stack.extend(stack[i].children.values())
+            stack.extend(sorted(stack[i].children.values(), key=lambda node: node.char))
             lookup.append(j)
             j += len(stack[i].children)
             i += 1

--- a/triegex/__init__.py
+++ b/triegex/__init__.py
@@ -40,7 +40,7 @@ class TriegexNode:
     def to_regex(self):
         '''
         RECURSIVE IMPLEMENTATION FOR REFERENCE
-        suffixes = reversed([v.to_regex() for k, v in self.children.items()])
+        suffixes = [v.to_regex() for k, v in self.children.items()]
         if self.end:
             suffixes += [WORD_BOUNDARY]
         
@@ -73,8 +73,7 @@ class TriegexNode:
             i -= 1
             node = stack[i]
             # Get regexes of child nodes and make a root regex
-            # Iterate backwards because otherwise alphabetical ordering is incorrect
-            suffixes = [sub_regexes[lookup[i] + len(node.children) - 1 - child] for child in range(0, len(node.children))]
+            suffixes = [sub_regexes[child] for child in range(lookup[i], lookup[i] + len(node.children))]
             if node.end:
                 # if the node is an ending node we add a \b character
                 suffixes += [WORD_BOUNDARY]


### PR DESCRIPTION
I have made a fix for the [issue about incorrect output](https://github.com/ZhukovAlexander/triegex/issues/7) I brought up.

All the unit tests included passed, except one which had a problem with the following change in the output:
`~^(?#match nothing)` is now placed at the beginning of the regex instead of the end, if this is a problem I can alter the algorithm to take care of this edge case. 
I've changed the corresponding unit test to reflect the new behaviour.
[See this commit.](https://github.com/ZhukovAlexander/triegex/commit/d9fed24e806d2e65756ae3b77a756f2a930184cf)

I've also fixed a mistake in the grammar regarding `childrens` because the correct word should be `children`, if this change seems unnecessary and problematic, tell me.
[Change in this commit](https://github.com/ZhukovAlexander/triegex/commit/88508620b7b4bbcc1d1308afa286d8b3395ad683)